### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,8 +13,8 @@ PyYAML>=5.3.1
 requests>=2.23.0
 scipy>=1.4.1
 thop>=0.1.1
-torch>=1.7.0
-torchvision>=0.8.1
+"torch>=1.7.0,<=1.13.1"
+"torchvision>=0.8.1,<=0.14.1"
 tqdm>=4.64.0
 # protobuf<=3.20.1
 


### PR DESCRIPTION
Since in PyTorch 2 dashes are preferred over underscores (https://github.com/pytorch/pytorch/pull/94505), **local-rank** that is propagated by distributed training `torch.distributed.launch` script, it is not compatible with the python training scripts. This commit allows installation of the correct pytorch and torchvision versions. 